### PR TITLE
Clears global state when rails reloads classes

### DIFF
--- a/lib/lazy_observers.rb
+++ b/lib/lazy_observers.rb
@@ -1,6 +1,7 @@
 require 'lazy_observers/version'
 require 'active_record'
 require 'active_record/observer'
+require 'lazy_observers/railtie' if defined?(Rails)
 
 module LazyObservers
   def self.observed_loaded(klass)
@@ -34,6 +35,11 @@ module LazyObservers
 
   def self.debug_active_record_loading
     ActiveRecord::Base.send(:extend, LazyObservers::InheritedDebugger)
+  end
+
+  def self.clear
+    @observers = {}
+    @loaded = []
   end
 
   private

--- a/lib/lazy_observers/railtie.rb
+++ b/lib/lazy_observers/railtie.rb
@@ -1,0 +1,7 @@
+module LazyObservers
+  class Railtie < Rails::Railtie
+    config.to_prepare do
+      LazyObservers.clear
+    end
+  end
+end


### PR DESCRIPTION
If state is not cleared, observers hash will continue to grow resulting in memory leaks. I'm also adding support for Rails 4, and if we don't clear the observers hash, Rails will raise error "A copy of xxx has been removed from the module tree but is still active".

Also, note that `observers[observer] = classes` won't replace the value for that observer since hash will use object_id and not observer name as the hash key.
