### PR TITLE
Adds support for Rails 4.

### DIFF
--- a/lib/lazy_observers.rb
+++ b/lib/lazy_observers.rb
@@ -1,6 +1,6 @@
 require 'lazy_observers/version'
 require 'active_record'
-require 'active_record/observer'
+require 'lazy_observers/rails_observer'
 
 module LazyObservers
   def self.observed_loaded(klass)

--- a/lib/lazy_observers/rails_observer.rb
+++ b/lib/lazy_observers/rails_observer.rb
@@ -1,0 +1,14 @@
+if ActiveRecord::VERSION::MAJOR < 4
+  require 'active_record/observer'
+else
+  begin
+    require 'rails/observers/active_model/observing'
+    require 'rails/observers/activerecord/observer'
+  rescue LoadError => _
+    $stderr.puts(<<-MSG)
+ERROR: Failed loading rails-observers dependencies.
+If you are using Rails 4+, make sure `gem 'rails-observers'` is in your Gemfile.
+    MSG
+    raise
+  end
+end


### PR DESCRIPTION
ActiveRecord::Observer was extracted from Rails 4 to its own gem. See (http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-3-2-to-rails-4-0), so LazyObservers needs to require the files from that gem if running in Rails 4.
